### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -22,9 +22,7 @@
     {
       "plugin": "@nx/js/typescript",
       "options": {
-        "typecheck": {
-          "targetName": "typecheck"
-        },
+        "typecheck": { "targetName": "typecheck" },
         "build": {
           "targetName": "build",
           "configName": "tsconfig.lib.json",
@@ -33,12 +31,7 @@
         }
       }
     },
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    },
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
     {
       "plugin": "@nx/next/plugin",
       "options": {
@@ -58,28 +51,29 @@
       "inputs": ["production", "^production", "sharedGlobals"]
     },
     "@nx/js:tsc": {
-        "cache": true,
-        "dependsOn": ["^build"],
-        "inputs": ["default", "^default", "sharedGlobals"],
-        "outputs": ["{options.outputPath}"]
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["default", "^default", "sharedGlobals"],
+      "outputs": ["{options.outputPath}"]
     },
     "@nx/next:build": {
-        "cache": true,
-        "dependsOn": ["^build"],
-        "inputs": ["production", "^production", "sharedGlobals"],
-        "outputs": ["{options.outputPath}"]
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production", "sharedGlobals"],
+      "outputs": ["{options.outputPath}"]
     },
     "@nx/eslint:lint": {
-        "cache": true,
-        "inputs": ["default", "{workspaceRoot}/.eslintrc.json", "{workspaceRoot}/eslint.config.mjs", "sharedGlobals"]
+      "cache": true,
+      "inputs": [
+        "default",
+        "{workspaceRoot}/.eslintrc.json",
+        "{workspaceRoot}/eslint.config.mjs",
+        "sharedGlobals"
+      ]
     }
   },
   "generators": {
-    "@nx/next": {
-      "application": {
-        "style": "css",
-        "linter": "eslint"
-      }
-    }
-  }
+    "@nx/next": { "application": { "style": "css", "linter": "eslint" } }
+  },
+  "nxCloudId": "67f860820ca166d446f149b8"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/67f8606f2b3ff01bc0785b73/workspaces/67f860820ca166d446f149b8

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.